### PR TITLE
uvm_reg.cpp: added missing initialization in predict()

### DIFF
--- a/src/uvmsc/reg/uvm_reg.cpp
+++ b/src/uvmsc/reg/uvm_reg.cpp
@@ -1117,7 +1117,10 @@ bool uvm_reg::predict( uvm_reg_data_t value,
 {
   uvm_reg_item* rw = new uvm_reg_item();
 
-  rw->value.resize(1);
+  // make sure we have reserved space to store an initial value
+  if (rw->value.size() == 0)
+    rw->value.resize(1);
+
   rw->value[0] = value;
   rw->path = path;
   rw->map = map;


### PR DESCRIPTION
Value array was not initialized. This fixes https://github.com/OSCI-WG/uvm-systemc-regressions/issues/20
