### PR TITLE
Added namespaces within reporting macros to fix compiler dependent output

### DIFF
--- a/src/uvmsc/macros/uvm_message_defines.h
+++ b/src/uvmsc/macros/uvm_message_defines.h
@@ -62,8 +62,8 @@
 //----------------------------------------------------------------------
 
 #define UVM_INFO(ID,MSG,VERBOSITY) \
-  if (uvm_report_enabled(VERBOSITY, ::uvm::UVM_INFO, ID)) \
-    uvm_report_info(ID, MSG, VERBOSITY, __FILE__, __LINE__)
+  if (uvm::uvm_report_enabled(VERBOSITY, ::uvm::UVM_INFO, ID)) \
+    uvm::uvm_report_info(ID, MSG, VERBOSITY, __FILE__, __LINE__)
 
 //----------------------------------------------------------------------
 // MACRO: UVM_WARNING
@@ -76,8 +76,8 @@
 //----------------------------------------------------------------------
 
 #define UVM_WARNING(ID,MSG) \
-  if (uvm_report_enabled((int)::uvm::UVM_NONE, ::uvm::UVM_WARNING, std::string(ID))) \
-    uvm_report_warning(ID, MSG, ::uvm::UVM_NONE, UVM_FILE_M, UVM_LINE_M)
+  if (uvm::uvm_report_enabled((int)::uvm::UVM_NONE, ::uvm::UVM_WARNING, std::string(ID))) \
+    uvm::uvm_report_warning(ID, MSG, ::uvm::UVM_NONE, UVM_FILE_M, UVM_LINE_M)
 
 //----------------------------------------------------------------------
 // MACRO: UVM_ERROR
@@ -90,8 +90,8 @@
 //----------------------------------------------------------------------
 
 #define UVM_ERROR(ID,MSG) \
-  if (uvm_report_enabled(::uvm::UVM_NONE, ::uvm::UVM_ERROR, ID)) \
-    uvm_report_error(ID, MSG, ::uvm::UVM_NONE, UVM_FILE_M, UVM_LINE_M)
+  if (uvm::uvm_report_enabled(::uvm::UVM_NONE, ::uvm::UVM_ERROR, ID)) \
+    uvm::uvm_report_error(ID, MSG, ::uvm::UVM_NONE, UVM_FILE_M, UVM_LINE_M)
 
 //----------------------------------------------------------------------
 // MACRO: UVM_FATAL
@@ -104,8 +104,8 @@
 //----------------------------------------------------------------------
 
 #define UVM_FATAL(ID,MSG) \
-  if (uvm_report_enabled(::uvm::UVM_NONE, ::uvm::UVM_FATAL, ID)) \
-    uvm_report_fatal(ID, MSG, ::uvm::UVM_NONE, UVM_FILE_M, UVM_LINE_M)
+  if (uvm::uvm_report_enabled(::uvm::UVM_NONE, ::uvm::UVM_FATAL, ID)) \
+    uvm::uvm_report_fatal(ID, MSG, ::uvm::UVM_NONE, UVM_FILE_M, UVM_LINE_M)
 
 
 #endif /* UVM_MESSAGE_DEFINES_H_ */


### PR DESCRIPTION
Depending on GCC version it could happen that `uvm::uvm_report_object::uvm_report_enabled` was found before `uvm::uvm_report_enabled` which leads to different output. This happens because the macros UVM_(INFO, WARNING, etc) call `uvm_report_enabled` without an proper namespace. This leads to log diffs in several files.

Examples (first line is GCC 4.4.7, second line is GCC 4.8.1 on the same machine on RHEL6):

examples/simple/producer_consumer/override:

> UVM_INFO <removed by verify-uvm.pl> @ 10 ns: topenv.parent_component.consumer [topenv.parent_component.consumer] fifo_consumer received: 16
> UVM_INFO <removed by verify-uvm.pl> @ 10 ns: reporter [topenv.parent_component.consumer] fifo_consumer received: 16

examples/simple/hello_world:

> UVM_INFO <removed by verify-uvm.pl> @ 0 s: top.producer1 [producer1] Starting.
> UVM_INFO <removed by verify-uvm.pl> @ 0 s: reporter [producer1] Starting.

This patch adds the `uvm::` namespace in the macro definition of UVM_(INFO, WARNING, etc) which would lead to the the GCC 4.8.1 output variant also for GCC 4.4.7.

If this PR is accepted, it would obselete https://github.com/OSCI-WG/uvm-systemc-regressions/pull/19 which has log diffs for the GCC 4.4.7 output variant.
