### PR TITLE
Nxp fix examples vcproj systemc include

### DIFF
--- a/examples/uvmsc/simple/callbacks/basic/msvc80/callbacks_basic.vcproj
+++ b/examples/uvmsc/simple/callbacks/basic/msvc80/callbacks_basic.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/configuration/manual/msvc80/configuration_manual.vcproj
+++ b/examples/uvmsc/simple/configuration/manual/msvc80/configuration_manual.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/factory/basic/msvc80/factory_basic.vcproj
+++ b/examples/uvmsc/simple/factory/basic/msvc80/factory_basic.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/hello_world/msvc80/hello_world.vcproj
+++ b/examples/uvmsc/simple/hello_world/msvc80/hello_world.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/objections/basic/msvc80/objections_basic.vcproj
+++ b/examples/uvmsc/simple/objections/basic/msvc80/objections_basic.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/phases/basic/msvc80/phases_basic.vcproj
+++ b/examples/uvmsc/simple/phases/basic/msvc80/phases_basic.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/phases/jump/msvc80/phases_jump.vcproj
+++ b/examples/uvmsc/simple/phases/jump/msvc80/phases_jump.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/phases/runtime/msvc80/phases_runtime.vcproj
+++ b/examples/uvmsc/simple/phases/runtime/msvc80/phases_runtime.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/phases/timeout/msvc80/phases_timeout.vcproj
+++ b/examples/uvmsc/simple/phases/timeout/msvc80/phases_timeout.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/producer_consumer/basic/msvc80/producer_consumer_basic.vcproj
+++ b/examples/uvmsc/simple/producer_consumer/basic/msvc80/producer_consumer_basic.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/producer_consumer/override/msvc80/producer_consumer_override.vcproj
+++ b/examples/uvmsc/simple/producer_consumer/override/msvc80/producer_consumer_override.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/reporting/error/msvc80/reporting_error.vcproj
+++ b/examples/uvmsc/simple/reporting/error/msvc80/reporting_error.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/reporting/info/msvc80/reporting_info.vcproj
+++ b/examples/uvmsc/simple/reporting/info/msvc80/reporting_info.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/reporting/warning/msvc80/reporting_warning.vcproj
+++ b/examples/uvmsc/simple/reporting/warning/msvc80/reporting_warning.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/scoreboard/basic/msvc80/scoreboard_basic.vcproj
+++ b/examples/uvmsc/simple/scoreboard/basic/msvc80/scoreboard_basic.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence/msvc80/basic_read_write_sequence.vcproj
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence/msvc80/basic_read_write_sequence.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence_tlm1/msvc80/basic_read_write_sequence_tlm1.vcproj
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence_tlm1/msvc80/basic_read_write_sequence_tlm1.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence_try/msvc80/basic_read_write_sequence_try.vcproj
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence_try/msvc80/basic_read_write_sequence_try.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/sequence/basic_read_write_start_item/msvc80/basic_read_write_start_item.vcproj
+++ b/examples/uvmsc/simple/sequence/basic_read_write_start_item/msvc80/basic_read_write_start_item.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/sequence/sequence_lock_grab/msvc80/sequence_lock_grab.vcproj
+++ b/examples/uvmsc/simple/sequence/sequence_lock_grab/msvc80/sequence_lock_grab.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/tlm1/bidir/msvc80/bidir.vcproj
+++ b/examples/uvmsc/simple/tlm1/bidir/msvc80/bidir.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/tlm1/hierarchy/msvc80/hierarchy.vcproj
+++ b/examples/uvmsc/simple/tlm1/hierarchy/msvc80/hierarchy.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/tlm1/producer_consumer/msvc80/producer_consumer.vcproj
+++ b/examples/uvmsc/simple/tlm1/producer_consumer/msvc80/producer_consumer.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"

--- a/examples/uvmsc/simple/trivial/msvc80/trivial.vcproj
+++ b/examples/uvmsc/simple/trivial/msvc80/trivial.vcproj
@@ -41,7 +41,7 @@
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
 				Optimization="0"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;_DEBUG;_LIB;_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -114,7 +114,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalOptions="/vmg"
-				AdditionalIncludeDirectories="&quot;$(ProjectDir)\..\..\..\..\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
+				AdditionalIncludeDirectories="&quot;$(UVMSYSTEMC)\..\src&quot;;&quot;$(SYSTEMC)\..\src&quot;"
 				PreprocessorDefinitions="WIN32;NDEBUG;_LIB;_USE_MATH_DEFINES;"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="0"


### PR DESCRIPTION
This fix replaces all hardcoded references to UVM SystemC and SystemC with variables UVMSYSTEMC and SYSTEMC, respectively.
