### PR TITLE
Removed unnecessary SC_FORK / SC_JOIN usage in tlm1/bidir example.

### DIFF
--- a/examples/uvmsc/simple/tlm1/bidir/bidir.h
+++ b/examples/uvmsc/simple/tlm1/bidir/bidir.h
@@ -61,10 +61,8 @@ class master : public uvm::uvm_component
   void run_phase( uvm::uvm_phase& phase)
   {
     // start sequences in parallel
-    SC_FORK
-      sc_core::sc_spawn(sc_bind(&master::request_process, this)),
-      sc_core::sc_spawn(sc_bind(&master::response_process, this))
-    SC_JOIN
+    sc_core::sc_spawn(sc_bind(&master::request_process, this));
+    sc_core::sc_spawn(sc_bind(&master::response_process, this));
   }
 
   void request_process()


### PR DESCRIPTION
Solves #17 