### PR TITLE
Fixes compilation errors due to iostream.h removal in SystemC

### DIFF
--- a/src/uvmsc/base/uvm_component.cpp
+++ b/src/uvmsc/base/uvm_component.cpp
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstring>
 #include <algorithm>
 
 #ifndef SC_INCLUDE_DYNAMIC_PROCESSES

--- a/src/uvmsc/base/uvm_transaction.cpp
+++ b/src/uvmsc/base/uvm_transaction.cpp
@@ -22,6 +22,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/base/uvm_transaction.h"
 #include "uvmsc/base/uvm_component.h"
 #include "uvmsc/print/uvm_printer.h"

--- a/src/uvmsc/cb/uvm_callback.cpp
+++ b/src/uvmsc/cb/uvm_callback.cpp
@@ -22,6 +22,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/cb/uvm_callback.h"
 #include "uvmsc/macros/uvm_callback_defines.h"
 

--- a/src/uvmsc/conf/uvm_queue.h
+++ b/src/uvmsc/conf/uvm_queue.h
@@ -26,6 +26,7 @@
 #define UVM_QUEUE_H_
 
 #include <string>
+#include <sstream>
 
 #include "uvmsc/base/uvm_object.h"
 #include "uvmsc/base/uvm_globals.h"

--- a/src/uvmsc/factory/uvm_component_registry.h
+++ b/src/uvmsc/factory/uvm_component_registry.h
@@ -27,6 +27,7 @@
 
 #include <systemc>
 #include <string>
+#include <sstream>
 
 #include "uvmsc/base/uvm_component.h"
 #include "uvmsc/report/uvm_report_object.h"

--- a/src/uvmsc/factory/uvm_object_registry.h
+++ b/src/uvmsc/factory/uvm_object_registry.h
@@ -26,6 +26,7 @@
 #define UVM_OBJECT_REGISTRY_H_
 
 #include <string>
+#include <sstream>
 #include <systemc>
 
 #include "uvmsc/base/uvm_component.h"

--- a/src/uvmsc/misc/uvm_misc.cpp
+++ b/src/uvmsc/misc/uvm_misc.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <functional>
 #include <iomanip>
+#include <sstream>
 
 #include <systemc>
 

--- a/src/uvmsc/misc/uvm_scope_stack.cpp
+++ b/src/uvmsc/misc/uvm_scope_stack.cpp
@@ -22,6 +22,7 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
 #include <systemc>
 
 #include "uvmsc/misc/uvm_scope_stack.h"

--- a/src/uvmsc/phasing/uvm_bottomup_phase.cpp
+++ b/src/uvmsc/phasing/uvm_bottomup_phase.cpp
@@ -22,6 +22,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/base/uvm_globals.h"
 #include "uvmsc/macros/uvm_message_defines.h"
 #include "uvmsc/phasing/uvm_bottomup_phase.h"

--- a/src/uvmsc/phasing/uvm_objection.cpp
+++ b/src/uvmsc/phasing/uvm_objection.cpp
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 
 #include "uvmsc/base/uvm_object_globals.h"
 #include "uvmsc/base/uvm_component.h"

--- a/src/uvmsc/phasing/uvm_process_phase.cpp
+++ b/src/uvmsc/phasing/uvm_process_phase.cpp
@@ -22,6 +22,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/base/uvm_object_globals.h"
 #include "uvmsc/base/uvm_globals.h"
 #include "uvmsc/seq/uvm_sequencer_base.h"

--- a/src/uvmsc/phasing/uvm_topdown_phase.cpp
+++ b/src/uvmsc/phasing/uvm_topdown_phase.cpp
@@ -22,6 +22,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/base/uvm_globals.h"
 #include "uvmsc/phasing/uvm_phase.h"
 #include "uvmsc/phasing/uvm_topdown_phase.h"

--- a/src/uvmsc/print/uvm_printer.cpp
+++ b/src/uvmsc/print/uvm_printer.cpp
@@ -22,6 +22,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/base/uvm_component.h"
 #include "uvmsc/base/uvm_object.h"
 #include "uvmsc/print/uvm_printer.h"

--- a/src/uvmsc/report/uvm_report_handler.cpp
+++ b/src/uvmsc/report/uvm_report_handler.cpp
@@ -20,6 +20,8 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------------
 
+#include <sstream>
+
 #include "uvmsc/report/uvm_report_handler.h"
 #include "uvmsc/report/uvm_report_server.h"
 #include "uvmsc/base/uvm_version.h"

--- a/src/uvmsc/seq/uvm_sequence_base.cpp
+++ b/src/uvmsc/seq/uvm_sequence_base.cpp
@@ -22,6 +22,7 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+#include <sstream>
 #include <systemc>
 #include "sysc/kernel/sc_dynamic_processes.h"
 

--- a/src/uvmsc/seq/uvm_sequencer_param_base.h
+++ b/src/uvmsc/seq/uvm_sequencer_param_base.h
@@ -23,6 +23,7 @@
 #ifndef UVM_SEQUENCER_PARAM_BASE_H_
 #define UVM_SEQUENCER_PARAM_BASE_H_
 
+#include <sstream>
 #include <tlm.h>
 
 #include <list>


### PR DESCRIPTION
This pull request adds includes for `sstream` and `cstring` in order to fix compilation problems as a result of https://github.com/OSCI-WG/systemc/pull/170 .