### PR TITLE
Using `sc_host_mutex` for m_atomic` in uvm_reg.h

### DIFF
--- a/src/uvmsc/reg/uvm_reg.h
+++ b/src/uvmsc/reg/uvm_reg.h
@@ -33,6 +33,8 @@
 #include "uvmsc/reg/uvm_hdl_path_concat.h"
 #include "uvmsc/conf/uvm_object_string_pool.h"
 
+#include "sysc/communication/sc_host_mutex.h"
+
 namespace uvm {
 
 // forward class declaration
@@ -431,7 +433,7 @@ class uvm_reg : public uvm_object
   mutable std::string m_fname;
   mutable int m_lineno;
 
-  sc_core::sc_mutex m_atomic; // semaphore
+  sc_core::sc_host_mutex m_atomic; // semaphore
   sc_core::sc_process_handle m_process;
   bool m_process_valid;
 


### PR DESCRIPTION
* `sc_mutex` cannot be used before start_of_simulation
* `build_phase` needs to be able to call `reg.reset()` within
elaboration phase
* this fixes https://github.com/OSCI-WG/uvm-systemc-regressions/issues/42 and partially https://github.com/OSCI-WG/uvm-systemc-regressions/issues/41