### PR TITLE
Fixed wrong conversion from glob paths to regex, ] must not be extended to \\] to be posix extended regex compatible

### DIFF
--- a/src/uvmsc/base/uvm_globals.cpp
+++ b/src/uvmsc/base/uvm_globals.cpp
@@ -1,5 +1,5 @@
 //----------------------------------------------------------------------
-//   Copyright 2018 COSEDA Technologies GmbH
+//   Copyright 2018-2019 COSEDA Technologies GmbH
 //   Copyright 2014 Universit� Pierre et Marie Curie, Paris
 //   Copyright 2014 Fraunhofer-Gesellschaft zur Foerderung
 //					der angewandten Forschung e.V.
@@ -383,11 +383,6 @@ const char* uvm_glob_to_re_char(const char *glob)
       case '[':
         uvm_re[len++] = '\\';
         uvm_re[len++] = '[';
-        break;
-
-      case ']':
-        uvm_re[len++] = '\\';
-        uvm_re[len++] = ']';
         break;
 
       case '(':


### PR DESCRIPTION
When compiling with -std=c++11 gcc and clang compilers are more strict about the regex syntax uvm uses. This leads to a runtime exception when matching ] brackets as in the ubus example. Especially it is not allowed to mark "]" as "\\]". In the default gnu mode this is not a problem as well as in posix regex ("regex.h") as they are not a strict when checking.

