### PR TITLE
Fix segment fault in uvm_sequencer_param_base class

### DIFF
--- a/src/uvmsc/seq/uvm_sequencer_param_base.h
+++ b/src/uvmsc/seq/uvm_sequencer_param_base.h
@@ -426,7 +426,7 @@ REQ* uvm_sequencer_param_base<REQ,RSP>::last_req(unsigned int n)
     return NULL;
   }
 
-  if(n == m_last_req_buffer.size()) 
+  if(n >= m_last_req_buffer.size()) 
   {
     return NULL;
   }
@@ -493,7 +493,7 @@ RSP* uvm_sequencer_param_base<REQ,RSP>::last_rsp(unsigned int n)
     return NULL;
   }
 
-  if(n == m_last_rsp_buffer.size()) 
+  if(n >= m_last_rsp_buffer.size()) 
   {
     return NULL;
   }


### PR DESCRIPTION
- Fixed segment fault issue when delete m_last_req_buffer, m_last_rsp_buffer list pointers in destructor of class uvm_sequencer_param_base as discussed in issue [#71](https://github.com/OSCI-WG/uvm-systemc-regressions/issues/71)

- Added the following methods which match to uvm-systemverilog standard:
_void set_num_last_reqs(unsigned int max);
unsigned int get_num_last_reqs();
REQ* last_req(unsigned int n = 0);
void set_num_last_rsps(unsigned int max);
unsigned int get_num_last_rsps();
RSP* last_rsp(unsigned int n = 0);_