### PR TITLE
fixed initialization of non-const members

### DIFF
--- a/examples/uvmsc/simple/callbacks/basic/bus_tr.h
+++ b/examples/uvmsc/simple/callbacks/basic/bus_tr.h
@@ -1,4 +1,5 @@
 //------------------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2007-2010 Mentor Graphics Corporation
@@ -37,10 +38,10 @@
 class bus_tr : public uvm::uvm_transaction
 {
  public:
-  int addr = 0;
-  int data = 0;
+  int addr;
+  int data;
 
-  bus_tr( std::string name = "bus_tr") {} // constructor
+  bus_tr( std::string name = "bus_tr"):addr(0),data(0) {} // constructor
 
   UVM_OBJECT_UTILS(bus_tr);
 

--- a/examples/uvmsc/simple/configuration/manual/classA.h
+++ b/examples/uvmsc/simple/configuration/manual/classA.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   Copyright 2009 Cadence Design Systems, Inc.
@@ -26,13 +27,14 @@
 
 class A : public uvm::uvm_component
 {
-  int debug = 0;
-  C* u1 = nullptr;
-  C* u2 = nullptr;
+  int debug;
+  C* u1;
+  C* u2;
 
  public:
 
-  A(uvm::uvm_component_name name) : uvm::uvm_component(name)
+  A(uvm::uvm_component_name name) : uvm::uvm_component(name),
+    debug(0),u1(0),u2(0)
   {}
 
   void build_phase(uvm::uvm_phase& phase)

--- a/examples/uvmsc/simple/configuration/manual/classB.h
+++ b/examples/uvmsc/simple/configuration/manual/classB.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   Copyright 2009 Cadence Design Systems, Inc.
@@ -26,11 +27,12 @@
 
 class B : public uvm::uvm_component
 {
-  int debug = 0;
-  C* u1 = nullptr;
+  int debug;
+  C* u1;
 
  public:
-  B(uvm::uvm_component_name name) : uvm::uvm_component(name)
+  B(uvm::uvm_component_name name) : uvm::uvm_component(name),
+    debug(0),u1(0)
   {}
 
   void build_phase(uvm::uvm_phase& phase)

--- a/examples/uvmsc/simple/configuration/manual/my_env.h
+++ b/examples/uvmsc/simple/configuration/manual/my_env.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   Copyright 2009 Cadence Design Systems, Inc.
@@ -31,13 +32,14 @@ class my_env : public uvm::uvm_env
 {
  public:
 
-  int debug = 0;
-  A* inst1 = nullptr;
-  B* inst2 = nullptr;
+  int debug;
+  A* inst1;
+  B* inst2;
 
   UVM_COMPONENT_UTILS(my_env);
 
-  my_env(uvm::uvm_component_name name) : uvm::uvm_env(name)
+  my_env(uvm::uvm_component_name name) : uvm::uvm_env(name),
+    debug(0),inst1(0),inst2(0)
   {}
 
   void build_phase(uvm::uvm_phase& phase)

--- a/examples/uvmsc/simple/hello_world/packet.h
+++ b/examples/uvmsc/simple/hello_world/packet.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2014 NXP B.V.
 //   Copyright 2007-2010 Mentor Graphics Corporation
@@ -29,7 +30,7 @@
 class packet : public uvm::uvm_transaction
 {
  public:
-  int addr = 0;
+  int addr;
 
   UVM_OBJECT_UTILS(packet);
 
@@ -37,7 +38,7 @@ class packet : public uvm::uvm_transaction
   //constraint c { addr >= 0 && addr < 'h100; }
 
   packet( std::string name = "packet" )
-  : uvm_transaction(name)
+  : uvm_transaction(name),addr(0)
   {}
 
   virtual void do_print(const uvm::uvm_printer& printer) const

--- a/examples/uvmsc/simple/producer_consumer/basic/packet.h
+++ b/examples/uvmsc/simple/producer_consumer/basic/packet.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2009 Cadence Design Systems, Inc.
 //   Copyright 2012-2014 NXP B.V.
@@ -27,8 +28,10 @@
 class packet
 {
  public:
-  int addr = 0;
+  int addr;
   std::string name_;
+
+  packet():addr(0) {};
 
   std::ostream& operator<<(std::ostream& x) { x << name_ ; return x; }
 };

--- a/examples/uvmsc/simple/producer_consumer/override/packet.h
+++ b/examples/uvmsc/simple/producer_consumer/override/packet.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2009 Cadence Design Systems, Inc.
 //   Copyright 2012-2014 NXP B.V.
@@ -84,7 +85,7 @@ class packet : public uvm::uvm_object
   }
 
  public:
-  int data = 0;
+  int data;
 };
 
 /////////////////

--- a/examples/uvmsc/simple/scoreboard/basic/vip_packet.h
+++ b/examples/uvmsc/simple/scoreboard/basic/vip_packet.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -74,7 +75,7 @@ class vip_packet : public uvm::uvm_sequence_item
   }
 
  public:
-  int data = 0;
+  int data;
 };
 
 #endif /* VIP_PACKET_H_ */

--- a/examples/uvmsc/simple/sequence/arbitration/arb_seq.h
+++ b/examples/uvmsc/simple/sequence/arbitration/arb_seq.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -34,10 +35,10 @@ class arb_seq : public uvm::uvm_sequence<seq_arb_item>
  public:
   UVM_OBJECT_UTILS(arb_seq);
 
-  int seq_no = 0;
+  int seq_no;
 
   arb_seq( const std::string& name = "arb_seq" )
-    : uvm::uvm_sequence<seq_arb_item>(name)
+    : uvm::uvm_sequence<seq_arb_item>(name),seq_no(0)
   {}
 
   void body()

--- a/examples/uvmsc/simple/sequence/arbitration/seq_arb_driver.h
+++ b/examples/uvmsc/simple/sequence/arbitration/seq_arb_driver.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -35,10 +36,10 @@ class seq_arb_driver : public uvm::uvm_driver<seq_arb_item>
   UVM_COMPONENT_UTILS(seq_arb_driver);
 
   // Counters to keep track of sequence accesses
-  int seq_1 = 0;
-  int seq_2 = 0;
-  int seq_3 = 0;
-  int seq_4 = 0;
+  int seq_1;
+  int seq_2;
+  int seq_3;
+  int seq_4;
 
   seq_arb_driver( uvm::uvm_component_name name ) : uvm::uvm_driver<seq_arb_item>(name)
   {

--- a/examples/uvmsc/simple/sequence/arbitration/seq_arb_item.h
+++ b/examples/uvmsc/simple/sequence/arbitration/seq_arb_item.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -32,12 +33,12 @@ class seq_arb_item : public uvm::uvm_sequence_item
 {
  public:
 
-  int seq_no = 0;
+  int seq_no;
 
   UVM_OBJECT_UTILS(seq_arb_item);
 
   seq_arb_item( const std::string name = "seq_arb_item" )
-  : uvm::uvm_sequence_item(name)
+  : uvm::uvm_sequence_item(name), seq_no(0)
   {}
 
 }; // class seq_arb_item

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence/bus_trans.h
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence/bus_trans.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -90,9 +91,9 @@ class bus_trans : public uvm::uvm_sequence_item
   // data members
  public:
   // TODO: check types with UVM/SV original
-  unsigned addr = 0;
-  unsigned data = 0;
-  bus_op_t op = BUS_READ;
+  unsigned addr;
+  unsigned data;
+  bus_op_t op;
 };
 
 //--------------------------------------------------------------------

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence/sequenceA.h
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence/sequenceA.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -85,7 +86,7 @@ class sequenceA : public uvm::uvm_sequence<REQ,RSP>
  private:
   // TODO: check types with UVM/SV original
   static unsigned int g_my_id;
-  unsigned int my_id = 0;
+  unsigned int my_id;
 };
 
 template <typename REQ, typename RSP>

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence_tlm1/bus_trans.h
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence_tlm1/bus_trans.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -91,9 +92,9 @@ class bus_trans : public uvm::uvm_sequence_item
   // data members
  public:
   // TODO: check types with UVM/SV original
-  unsigned int addr = 0;
-  unsigned int data = 0;
-  bus_op_t op = BUS_READ;
+  unsigned int addr;
+  unsigned int data;
+  bus_op_t op;
 };
 
 //--------------------------------------------------------------------

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence_tlm1/sequenceA.h
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence_tlm1/sequenceA.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -85,7 +86,7 @@ class sequenceA : public uvm::uvm_sequence<REQ,RSP>
  private:
   // TODO: check types with UVM/SV original
   static unsigned int g_my_id;
-  unsigned int my_id = 0;
+  unsigned int my_id;
 };
 
 // TODO: check types with UVM/SV original

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence_try/bus_trans.h
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence_try/bus_trans.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -90,9 +91,9 @@ class bus_trans : public uvm::uvm_sequence_item
   // data members
  public:
   // TODO: check types with UVM/SV original
-  unsigned int addr = 0;
-  unsigned int data = 0;
-  bus_op_t op = BUS_READ;
+  unsigned int addr;
+  unsigned int data;
+  bus_op_t op;
 };
 
 //--------------------------------------------------------------------

--- a/examples/uvmsc/simple/sequence/basic_read_write_sequence_try/sequenceA.h
+++ b/examples/uvmsc/simple/sequence/basic_read_write_sequence_try/sequenceA.h
@@ -1,4 +1,5 @@
 //----------------------------------------------------------------------
+//   Copyright 2020 Bosch Sensortec GmbH
 //   Copyright 2019 COSEDA Technologies GmbH
 //   Copyright 2012-2014 NXP B.V.
 //   All Rights Reserved Worldwide
@@ -85,7 +86,7 @@ class sequenceA : public uvm::uvm_sequence<REQ,RSP>
  private:
   // TODO: check types with UVM/SV original
   static unsigned int g_my_id;
-  unsigned int my_id = 0;
+  unsigned int my_id;
 };
 
 // TODO: check types with UVM/SV original

--- a/examples/uvmsc/simple/sequence/sequence_lock_grab/arb_seq.h
+++ b/examples/uvmsc/simple/sequence/sequence_lock_grab/arb_seq.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -34,10 +35,10 @@ class arb_seq : public uvm::uvm_sequence<seq_arb_item>
  public:
   UVM_OBJECT_UTILS(arb_seq);
 
-  int seq_no = 0;
+  int seq_no;
 
   arb_seq( const std::string& name = "arb_seq" )
-    : uvm::uvm_sequence<seq_arb_item>(name)
+    : uvm::uvm_sequence<seq_arb_item>(name), seq_no(0)
   {}
 
   void body()

--- a/examples/uvmsc/simple/sequence/sequence_lock_grab/grab_seq.h
+++ b/examples/uvmsc/simple/sequence/sequence_lock_grab/grab_seq.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -34,10 +35,10 @@ class grab_seq : public uvm::uvm_sequence<seq_arb_item>
  public:
   UVM_OBJECT_UTILS(grab_seq);
 
-  int seq_no = 0;
+  int seq_no;
 
   grab_seq( const std::string& name = "grab_seq" )
-    : uvm::uvm_sequence<seq_arb_item>(name)
+    : uvm::uvm_sequence<seq_arb_item>(name), seq_no(0)
   {}
 
   void body()

--- a/examples/uvmsc/simple/sequence/sequence_lock_grab/lock_seq.h
+++ b/examples/uvmsc/simple/sequence/sequence_lock_grab/lock_seq.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -34,10 +35,10 @@ class lock_seq : public uvm::uvm_sequence<seq_arb_item>
  public:
   UVM_OBJECT_UTILS(lock_seq);
 
-  int seq_no = 0;
+  int seq_no;
 
   lock_seq( const std::string& name = "lock_seq" )
-    : uvm::uvm_sequence<seq_arb_item>(name)
+    : uvm::uvm_sequence<seq_arb_item>(name), seq_no(0)
   {}
 
   void body()

--- a/examples/uvmsc/simple/sequence/sequence_lock_grab/seq_arb_driver.h
+++ b/examples/uvmsc/simple/sequence/sequence_lock_grab/seq_arb_driver.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -34,12 +35,12 @@ class seq_arb_driver : public uvm::uvm_driver<seq_arb_item>
   UVM_COMPONENT_UTILS(seq_arb_driver);
 
   // Counters to keep track of sequence accesses
-  int seq_1 = 0;
-  int seq_2 = 0;
-  int seq_3 = 0;
-  int seq_4 = 0;
-  int grab_seq = 0;
-  int lock_seq = 0;
+  int seq_1;
+  int seq_2;
+  int seq_3;
+  int seq_4;
+  int grab_seq;
+  int lock_seq;
 
   seq_arb_driver( uvm::uvm_component_name name ) : uvm::uvm_driver<seq_arb_item>(name)
   {

--- a/examples/uvmsc/simple/sequence/sequence_lock_grab/seq_arb_item.h
+++ b/examples/uvmsc/simple/sequence/sequence_lock_grab/seq_arb_item.h
@@ -2,6 +2,7 @@
 //   Copyright 2010 Mentor Graphics Corporation
 //   Copyright 2013-2014 NXP B.V.
 //   Copyright 2019 COSEDA Technologies GmbH
+//   Copyright 2020 Bosch Sensortec GmbH
 //   All Rights Reserved Worldwide
 //
 //   Licensed under the Apache License, Version 2.0 (the
@@ -32,12 +33,12 @@ class seq_arb_item : public uvm::uvm_sequence_item
 {
  public:
 
-  int seq_no = 0;
+  int seq_no;
 
   UVM_OBJECT_UTILS(seq_arb_item);
 
   seq_arb_item( const std::string name = "seq_arb_item" )
-  : uvm::uvm_sequence_item(name)
+  : uvm::uvm_sequence_item(name), seq_no(0)
   {}
 
 }; // class seq_arb_item


### PR DESCRIPTION
In-class initializations of non-const members where changed to adhere to the
C++ standard or removed where already present in the constructor(s).

This fixes #191 