### PR TITLE
Fix memory leakages in src

### DIFF
--- a/src/uvmsc/reg/uvm_reg_block.cpp
+++ b/src/uvmsc/reg/uvm_reg_block.cpp
@@ -1770,10 +1770,6 @@ bool uvm_reg_block::is_hdl_path_root( std::string kind ) const
 
 uvm_reg_block::~uvm_reg_block()
 {
-  for( m_maps_citt it = m_maps.begin(); it != m_maps.end(); it++)
-    uvm_reg_map::type_id::destroy((*it).first);
- 
-  m_maps.clear(); 
   m_hdl_paths_pool.clear();
   m_root_hdl_paths.clear();
 }

--- a/src/uvmsc/reg/uvm_reg_fifo.cpp
+++ b/src/uvmsc/reg/uvm_reg_fifo.cpp
@@ -66,8 +66,6 @@ void uvm_reg_fifo::build()
   m_value = uvm_reg_field::type_id::create("value");
   sc_bv<32> reset_value = 0x0;
   m_value->configure(this, get_n_bits(), 0, "RW", false, reset_value, true, false, true);
-  
-  m_value_list.push_back(m_value);
 }
 
 
@@ -318,21 +316,5 @@ void uvm_reg_fifo::post_randomize()
   m_set_cnt = 0;
 }
 
-//----------------------------------------------------------------------
-// Destructor
-//
-//! Clean up memory allocation
-//----------------------------------------------------------------------
-
-uvm_reg_fifo::~uvm_reg_fifo()
-{
-  for (std::vector<uvm_reg_field*>::iterator
-       it = m_value_list.begin();
-       it != m_value_list.end();
-       it ++)
-    uvm_reg_field::type_id::destroy(*it);
-
-  m_value_list.clear();
-}
 
 } // namespace uvm

--- a/src/uvmsc/reg/uvm_reg_fifo.h
+++ b/src/uvmsc/reg/uvm_reg_fifo.h
@@ -121,13 +121,10 @@ class uvm_reg_fifo : public uvm_reg
     fifo.size() <= m_size;
   }
   */
-  virtual ~uvm_reg_fifo();
-
 
   // local data members
 private:
   uvm_reg_field* m_value;
-  std::vector<uvm_reg_field*> m_value_list;
   int m_set_cnt;
   unsigned int m_size;
 

--- a/src/uvmsc/report/uvm_report_object.cpp
+++ b/src/uvmsc/report/uvm_report_object.cpp
@@ -499,7 +499,6 @@ void uvm_report_object::reset_report_handler()
 void uvm_report_object::start_report_handler(const std::string& name)
 {
   m_rh = uvm_report_handler::type_id::create(name);
-  m_rh_list.push_back(m_rh);
 }
 
 
@@ -518,13 +517,6 @@ void uvm_report_object::start_report_handler(const std::string& name)
 
 uvm_report_object::~uvm_report_object()
 {
-  for (std::vector<uvm_report_handler*>::iterator
-       it = m_rh_list.begin();
-       it != m_rh_list.end();
-       it ++)
-    uvm_report_handler::type_id::destroy(*it);
-  
-  m_rh_list.clear();
 }
 
 

--- a/src/uvmsc/report/uvm_report_object.h
+++ b/src/uvmsc/report/uvm_report_object.h
@@ -199,7 +199,6 @@ class uvm_report_object : public uvm_object
 
  protected:
   uvm_report_handler* m_rh;
-  std::vector<uvm_report_handler*> m_rh_list;
 };
 
 


### PR DESCRIPTION
Fixed memory leakage in src (mainly from uvmsc/reg) where pointers are created using `type_id::create` without deleting. The fix will use `type_id::destroy` method in #189 to delete these pointers. 

This pull request doesn't be affected by other pull requests, then it can be merged immediately after reviewing.
