### PR TITLE
added report redirection to UVM_OBJECT_*_UTILS

### DIFF
--- a/src/uvmsc/macros/uvm_object_defines.h
+++ b/src/uvmsc/macros/uvm_object_defines.h
@@ -81,6 +81,41 @@
        return uvm::uvm_report_enabled(verbosity,severity,id);                                             \
     }                                                                                                     \
                                                                                                           \
+    /* uvm_report */                                                                                      \
+    template<typename __PSI_TYPE = __VA_ARGS__>                                                           \
+    typename std::enable_if<IsSequenceItem<__PSI_TYPE>::result>::type uvm_report(                         \
+            uvm::uvm_severity severity,                                                                   \
+            const std::string& id,                                                                        \
+            const std::string& message,                                                                   \
+            int verbosity = uvm::UVM_MEDIUM,                                                              \
+            const std::string& filename = "",                                                             \
+            int line = 0,                                                                                 \
+            const std::string& context_name = "",                                                         \
+            bool report_enabled_checked = false ) const {                                                 \
+        ((typename __PSI_TYPE::uvm_sequence_item*)this)->uvm_report_info(                                 \
+                id,                                                                                       \
+                message,                                                                                  \
+                verbosity,                                                                                \
+                filename,                                                                                 \
+                line,                                                                                     \
+                context_name,                                                                             \
+                report_enabled_checked                                                                    \
+                );                                                                                        \
+    }                                                                                                     \
+                                                                                                          \
+    template<typename __PSI_TYPE = __VA_ARGS__>                                                           \
+    typename std::enable_if<!IsSequenceItem<__PSI_TYPE>::result>::type uvm_report(                        \
+            uvm::uvm_severity severity,                                                                   \
+            const std::string& id,                                                                        \
+            const std::string& message,                                                                   \
+            int verbosity = uvm::UVM_NONE,                                                                \
+            const std::string& filename = "",                                                             \
+            int line = 0,                                                                                 \
+            const std::string& context_name = "",                                                         \
+            bool report_enabled_checked = false ) const {                                                 \
+        uvm::uvm_report_info(id,message,verbosity,filename,line,context_name,report_enabled_checked);     \
+    }                                                                                                     \
+                                                                                                          \
     /* uvm_report_info */                                                                                 \
     template<typename __PSI_TYPE = __VA_ARGS__>                                                           \
     typename std::enable_if<IsSequenceItem<__PSI_TYPE>::result>::type uvm_report_info(                    \


### PR DESCRIPTION
The redirection calls the proper uvm_report_enabled and uvm_report_* methods depending if the calling class inherited from uvm_sequence_item. This fixes https://github.com/OSCI-WG/uvm-systemc-regressions/issues/74.