### PR TITLE
Fixed destroy component/object in factory 

### DIFF
--- a/src/uvmsc/base/uvm_root.cpp
+++ b/src/uvmsc/base/uvm_root.cpp
@@ -603,7 +603,16 @@ void uvm_root::m_unregister_test( const std::string& test_name )
           it = comp_list.begin(); 
           it != comp_list.end(); 
           ++it)
-        factory->m_delete_component((*it)->get_inst_id());
+      {
+        if (!factory->m_delete_component(*it))
+        {
+          std::ostringstream msg;
+          msg << "Could not destroy component of type '" << (*it)->get_type_name()
+              << "', name=" << (*it)->get_name()
+              << " from factory";
+          uvm_report_error("CMPNDEL", msg.str(), UVM_NONE);
+        }
+      }
     }
   }
 }

--- a/src/uvmsc/factory/uvm_component_registry.h
+++ b/src/uvmsc/factory/uvm_component_registry.h
@@ -96,7 +96,7 @@ class uvm_component_registry : public uvm_object_wrapper
   // not part of UVM Class reference / LRM
   /////////////////////////////////////////////////////
   //
-  static void destroy( T* comp );
+  static void destroy( T*& comp );
 
   virtual ~uvm_component_registry();
 
@@ -296,7 +296,7 @@ const std::string uvm_component_registry<T>::m_type_name_prop()
 //----------------------------------------------------------------------
 
 template <typename T>
-void uvm_component_registry<T>::destroy( T* comp ) 
+void uvm_component_registry<T>::destroy( T*& comp ) 
 {
   if (comp == NULL) 
   {
@@ -317,7 +317,7 @@ void uvm_component_registry<T>::destroy( T* comp )
     return;
   }
 
-  if (!f->m_delete_component(comp->get_inst_id()))
+  if (!f->m_delete_component(comp))
   {
     std::ostringstream msg;
     msg << "Could not destroy component of type '" << comp->get_type_name()
@@ -343,10 +343,6 @@ uvm_component_registry<T>::~uvm_component_registry()
     delete me;
     me = NULL;
   }
-
-  uvm_coreservice_t* cs = uvm_coreservice_t::get();
-  uvm_factory* f = cs->get_factory();
-  f->m_delete_all_components();
 }
 
 

--- a/src/uvmsc/factory/uvm_default_factory.cpp
+++ b/src/uvmsc/factory/uvm_default_factory.cpp
@@ -136,6 +136,18 @@ uvm_default_factory::~uvm_default_factory()
 
     delete it->second; // delete uvm_factory_queue_class objects
   }
+
+  for( m_comp_t_listItT 
+       it = m_comp_t_list.begin();
+       it != m_comp_t_list.end(); 
+       it++)
+    delete (*it); // delete created uvm_component
+  
+  for( m_obj_t_listItT 
+       it = m_obj_t_list.begin();
+       it != m_obj_t_list.end(); 
+       it++)
+    delete (*it); // delete created uvm_object
 }
 
 //----------------------------------------------------------------------------
@@ -572,7 +584,7 @@ uvm_object* uvm_default_factory::create_object_by_type( uvm_object_wrapper* requ
   requested_type = find_override_by_type(requested_type, full_inst_path);
 
   uvm_object* obj = requested_type->create_object(name);
-  m_obj_t_map[obj->get_inst_id()] = obj; // register object so we can delete after use
+  m_obj_t_list.push_back(obj);
 
   return obj;
 }
@@ -600,7 +612,7 @@ uvm_component* uvm_default_factory::create_component_by_type( uvm_object_wrapper
   requested_type = find_override_by_type(requested_type, full_inst_path);
   
   uvm_component* comp = requested_type->create_component(name, parent);
-  m_comp_t_map[comp->get_inst_id()] = comp; // register comp so we can delete after use
+  m_comp_t_list.push_back(comp);
 
   return comp; 
 }
@@ -642,7 +654,7 @@ uvm_object* uvm_default_factory::create_object_by_name( const std::string& reque
   }
 
   uvm_object* obj = wrapper->create_object(name);
-  m_obj_t_map[obj->get_inst_id()] = obj; // register object so we can delete after use
+  m_obj_t_list.push_back(obj);
 
   return obj;
 }
@@ -685,7 +697,7 @@ uvm_component* uvm_default_factory::create_component_by_name( const std::string&
     wrapper = m_type_names[requested_type_name];
   }
   uvm_component* comp = wrapper->create_component(name, parent);
-  m_comp_t_map[comp->get_inst_id()] = comp; // register comp so we can delete after use
+  m_comp_t_list.push_back(comp);
 
   return comp;
 }
@@ -1416,15 +1428,15 @@ void uvm_default_factory::m_debug_display( const std::string& requested_type_nam
 //! Implementation-defined member function
 //----------------------------------------------------------------------------
 
-bool uvm_default_factory::m_delete_object( int obj_id )
+bool uvm_default_factory::m_delete_object(uvm_object* obj)
 {
-  m_obj_t_mapItT it = m_obj_t_map.find(obj_id);
+  m_obj_t_listItT it = std::find(m_obj_t_list.begin(), m_obj_t_list.end(), obj);
 
-  if ( it == m_obj_t_map.end() )
-    return false; // id not found, so nothing to delete
+  if (it == m_obj_t_list.end())
+    return false;
 
-  delete it->second; // delete object registered in map
-  m_obj_t_map.erase(obj_id); // clear map entry
+  delete (*it);
+  m_obj_t_list.erase(it);
 
   return true;
 }
@@ -1436,11 +1448,13 @@ bool uvm_default_factory::m_delete_object( int obj_id )
 //----------------------------------------------------------------------------
 void uvm_default_factory::m_delete_all_objects()
 {
-  for( m_obj_t_mapItT it = m_obj_t_map.begin();
-     it!=m_obj_t_map.end(); ++it)
-  delete it->second;
+  for( m_obj_t_listItT 
+       it = m_obj_t_list.begin();
+       it != m_obj_t_list.end(); 
+       it++)
+    delete (*it);
 
-  m_obj_t_map.clear(); // empty whole list
+  m_obj_t_list.clear();
 }
 
 //----------------------------------------------------------------------------
@@ -1449,15 +1463,15 @@ void uvm_default_factory::m_delete_all_objects()
 //! Implementation-defined member function
 //----------------------------------------------------------------------------
 
-bool uvm_default_factory::m_delete_component( int comp_id )
+bool uvm_default_factory::m_delete_component( uvm_component* comp )
 {
-  m_comp_t_mapItT it = m_comp_t_map.find(comp_id);
+  m_comp_t_listItT it = std::find(m_comp_t_list.begin(), m_comp_t_list.end(), comp);
 
-  if ( it == m_comp_t_map.end() )
-    return false; // id not found, so nothing to delete
+  if (it == m_comp_t_list.end())
+    return false;
 
-  delete it->second; // delete object registered in map
-  m_comp_t_map.erase(comp_id); // clear map entry
+  delete (*it);
+  m_comp_t_list.erase(it);
 
   return true;
 }
@@ -1469,11 +1483,13 @@ bool uvm_default_factory::m_delete_component( int comp_id )
 //----------------------------------------------------------------------------
 void uvm_default_factory::m_delete_all_components()
 {
-  for( m_comp_t_mapItT it = m_comp_t_map.begin();
-     it!=m_comp_t_map.end(); ++it)
-  delete it->second;
+  for( m_comp_t_listItT 
+       it = m_comp_t_list.begin();
+       it != m_comp_t_list.end(); 
+       it++)
+    delete (*it);
 
-  m_comp_t_map.clear(); // empty whole list
+  m_comp_t_list.clear();
 }
 
 ////////////////////

--- a/src/uvmsc/factory/uvm_default_factory.h
+++ b/src/uvmsc/factory/uvm_default_factory.h
@@ -133,10 +133,10 @@ public:
   // not part of UVM Class reference / LRM
   /////////////////////////////////////////////////////
 
-  bool m_delete_object( int obj_id );
+  bool m_delete_object( uvm_object* obj );
   void m_delete_all_objects();
 
-  bool m_delete_component( int comp_id );
+  bool m_delete_component( uvm_component* comp );
   void m_delete_all_components();
 
  protected:

--- a/src/uvmsc/factory/uvm_factory.h
+++ b/src/uvmsc/factory/uvm_factory.h
@@ -155,23 +155,23 @@ class uvm_factory
 
   // implementation defined methods
 
-  virtual bool m_delete_object( int obj_id ) = 0;
+  virtual bool m_delete_object( uvm_object* obj ) = 0;
   virtual void m_delete_all_objects() = 0;
 
-  virtual bool m_delete_component( int comp_id ) = 0;
+  virtual bool m_delete_component( uvm_component* comp ) = 0;
   virtual void m_delete_all_components() = 0;
 
  protected:
   uvm_factory(){};
   virtual ~uvm_factory(){};
 
-  typedef std::map<int,uvm_object* > m_obj_t_mapT;
-  typedef m_obj_t_mapT::iterator m_obj_t_mapItT;
-  m_obj_t_mapT m_obj_t_map;
+  typedef std::list<uvm_object* > m_obj_t_listT;
+  typedef m_obj_t_listT::iterator m_obj_t_listItT;
+  m_obj_t_listT m_obj_t_list;
 
-  typedef std::map<int,uvm_component* > m_comp_t_mapT;
-  typedef m_comp_t_mapT::iterator m_comp_t_mapItT;
-  m_comp_t_mapT m_comp_t_map;
+  typedef std::list<uvm_component* > m_comp_t_listT;
+  typedef m_comp_t_listT::iterator m_comp_t_listItT;
+  m_comp_t_listT m_comp_t_list;
 
 }; // class uvm_factory
 

--- a/src/uvmsc/factory/uvm_object_registry.h
+++ b/src/uvmsc/factory/uvm_object_registry.h
@@ -95,7 +95,7 @@ class uvm_object_registry : public uvm_object_wrapper
   // not part of UVM Class reference / LRM
   /////////////////////////////////////////////////////
 
-  static void destroy( T* obj );
+  static void destroy( T*& obj );
 
  private:
   explicit uvm_object_registry( const std::string& name = "" );
@@ -306,7 +306,7 @@ const std::string uvm_object_registry<T>::m_type_name_prop()
 //----------------------------------------------------------------------
 
 template <typename T>
-void uvm_object_registry<T>::destroy( T* obj ) 
+void uvm_object_registry<T>::destroy( T*& obj ) 
 {
   if (obj == NULL) 
   {
@@ -316,7 +316,7 @@ void uvm_object_registry<T>::destroy( T* obj )
   uvm_coreservice_t* cs = uvm_coreservice_t::get();
   uvm_factory* f = cs->get_factory();
 
-  if (!f->m_delete_object(obj->get_inst_id()))
+  if (!f->m_delete_object(obj))
   {
     std::ostringstream msg;
     msg << "Could not destroy object of type '" << obj->get_type_name()
@@ -343,10 +343,6 @@ uvm_object_registry<T>::~uvm_object_registry()
     delete me;
     me = NULL;
   }
-
-  uvm_coreservice_t* cs = uvm_coreservice_t::get();
-  uvm_factory* f = cs->get_factory();
-  f->m_delete_all_objects();
 }
 
 


### PR DESCRIPTION
We used the `m_inst_id` to manage the created object/component in factory. Unfortunately, the following code causes the issue with default copy constructor of uvm_object pointers:
> p0 = obj::type_id::create("p0");
> p1 = obj::type_id::create("p1");
> *p0 = *p1;

The m_inst_id is changed for `p0`, then we could not delete the pointer correctly in factory.

The fix removes the `m_inst_id` and only search the pointer to be deleted.
Issue is a part of discussion in [https://github.com/OSCI-WG/uvm-systemc/issues/199](https://github.com/OSCI-WG/uvm-systemc/issues/199)