### PR TITLE
fixed deprecated use of std::ptr_fun

### DIFF
--- a/src/uvmsc/misc/uvm_misc.cpp
+++ b/src/uvmsc/misc/uvm_misc.cpp
@@ -269,7 +269,7 @@ const std::string uvm_string_queue_join( const std::vector<std::string>& q )
 std::string uvm_toupper( const std::string& str )
 {
   std::string s = str;
-  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::toupper(c); });
+  std::transform(s.begin(), s.end(), s.begin(), [](const unsigned char c) { return std::toupper(c); });
   return s;
 }
 


### PR DESCRIPTION
Remove use of std::ptr_fun which was deprecated in c++11 and removed from the c++17 standard. See https://en.cppreference.com/w/cpp/utility/functional/ptr_fun