### PR TITLE
Relaxed automake strictness

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_SUBST(UVM_VERSION)
 AC_SUBST(UVM_RELEASE_DATE)
 
 AC_CANONICAL_SYSTEM
-AM_INIT_AUTOMAKE([1.9.4 tar-pax -Werror -Wno-portability no-define subdir-objects])
+AM_INIT_AUTOMAKE([1.9.4 tar-pax -Werror -Wno-portability no-define subdir-objects foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES(yes)])
 
 # ignore GNU defaults for CFLAGS and CXXFLAGS


### PR DESCRIPTION
By default, Automake expects a file called `README` to be present. The recent rename to `README.md` caused a bootstrap error. This has been fixed by relaxing the strictness of Automake.