### PR TITLE
Added proposed fix for ubus_bus_monitor

### DIFF
--- a/examples/uvmsc/integrated/ubus/vip/ubus_bus_monitor.cpp
+++ b/examples/uvmsc/integrated/ubus/vip/ubus_bus_monitor.cpp
@@ -276,6 +276,7 @@ void ubus_bus_monitor::check_which_slave()
     if ((slave->get_min_addr() <= trans_addr) and
         (trans_addr <= slave->get_max_addr()))
     {
+      trans_collected.slave = name;
       slave_found = true;
       break;
     }


### PR DESCRIPTION
As proposed in https://forums.accellera.org/topic/7817-in-uvm-systemc-10-beta5-the-example-code-for-ubus-does-not-work-at-all-memory-locations

This fixes #312 .