### PR TITLE
Implents issue #330 Split do_compare in two methods without optional arguments

### DIFF
--- a/src/uvmsc/base/uvm_object.cpp
+++ b/src/uvmsc/base/uvm_object.cpp
@@ -477,10 +477,16 @@ bool uvm_object::compare( const uvm_object& rhs,
 //! otherwise.
 //----------------------------------------------------------------------------
 
+bool uvm_object::do_compare( const uvm_object& rhs) const
+{
+  uvm_report_warning("DOCOMP", "member function do_compare not implemented in " + get_type_name(), UVM_HIGH);
+  return true;
+}
+
 bool uvm_object::do_compare( const uvm_object& rhs,
                              const uvm_comparer* comparer ) const
 {
-  uvm_report_warning("DOCOMP", "member function do_compare not implemented in " + get_type_name(), UVM_HIGH);
+  uvm_report_warning("DOCOMP", "member function do_compare with comparer argument not implemented in " + get_type_name(), UVM_HIGH);
   return true;
 }
 

--- a/src/uvmsc/base/uvm_object.h
+++ b/src/uvmsc/base/uvm_object.h
@@ -153,8 +153,10 @@ public:
 
   bool compare( const uvm_object& rhs, const uvm_comparer* comparer = nullptr ) const;
 
+  virtual bool do_compare( const uvm_object& rhs) const;
+
   virtual bool do_compare( const uvm_object& rhs,
-                           const uvm_comparer* comparer = nullptr ) const;
+                           const uvm_comparer* comparer) const;
 
   //--------------------------------------------------------------------------
   // Group: Packing


### PR DESCRIPTION
Fix issue #330 